### PR TITLE
feat: add basic structure and tsconfig/jsconfig support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@
 
 A utility to resolve most non-vanilla JS import paths
 
+## Usage
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["./*"] }
+  }
+}
+```
+
+```ts
+import { generateResolver } from "deema";
+
+const resolve = generateResolver("/my/root/path");
+
+resolve("src/component/main.ts", "@/shared/sum"); // "../shared/sum"
+```
+
 ## [Work in progress](https://github.com/benawad/destiny/issues/123)
 
 This repo is more of an experiment for now. We'll see if its concept become viable.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "format:eslint": "npm run lint -- --fix",
     "format:prettier": "prettier --write '{**/*,*}.{js,json,md,ts,yaml}'",
     "format:destiny": "destiny --write",
-    "lint": "eslint '{**/*,*}.{js,ts}'"
+    "lint": "eslint '{**/*,*}.{js,ts}'",
+    "test": "jest"
   },
   "devDependencies": {
+    "@types/jest": "^26.0.15",
     "@typescript-eslint/eslint-plugin": "^3.8.0",
     "@typescript-eslint/parser": "^3.8.0",
     "destiny": "^0.7.0",
@@ -29,11 +31,16 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
+    "jest": "^26.6.3",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "rollup": "^2.23.1",
     "rollup-plugin-dts": "^1.4.10",
     "rollup-plugin-esbuild": "^2.4.2",
+    "ts-jest": "^26.4.4",
     "typescript": "^3.9.7"
+  },
+  "dependencies": {
+    "find-up": "^5.0.0"
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,14 @@
+import { resolve as resolvePath } from "path";
+import { generateResolver } from "./index";
+
+describe("generateResolver", () => {
+  const resolve = generateResolver(
+    resolvePath(__dirname, "index/__fixtures/page")
+  );
+  it("should not resolve relative path", () => {
+    expect(resolve("./page/main.ts", "./page2")).toBe("./page2");
+  });
+  it("should resolved based on tsconfig", () => {
+    expect(resolve("./page/main.ts", "@/helpers/sum")).toBe("../helpers/sum");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,10 @@
-export default (): string => "Hello world !";
+import { resolve } from "./index/resolve";
+import { resolveConfig } from "./index/resolveConfig";
+
+export function generateResolver(basePath: string = ".") {
+  const config = resolveConfig(basePath);
+  return (filePath: string, importPath: string) =>
+    resolve(filePath, importPath, config);
+}
+
+export { generateResolver as deema };

--- a/src/index/__fixtures/helpers/sum.ts
+++ b/src/index/__fixtures/helpers/sum.ts
@@ -1,0 +1,3 @@
+export function sum(a: number, b: number) {
+  return a + b;
+}

--- a/src/index/__fixtures/page/main.ts
+++ b/src/index/__fixtures/page/main.ts
@@ -1,0 +1,5 @@
+import { sum } from "@/helpers/sum";
+import { page2 } from "./page2";
+
+sum(2, 3);
+page2();

--- a/src/index/__fixtures/page/page2.ts
+++ b/src/index/__fixtures/page/page2.ts
@@ -1,0 +1,3 @@
+export function page2() {
+  return "page 2";
+}

--- a/src/index/__fixtures/tsconfig.json
+++ b/src/index/__fixtures/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["./*"] }
+  }
+}

--- a/src/index/config.ts
+++ b/src/index/config.ts
@@ -1,0 +1,4 @@
+export interface Config {
+  root: string;
+  tsconfig: any;
+}

--- a/src/index/resolve.ts
+++ b/src/index/resolve.ts
@@ -1,0 +1,18 @@
+import { Config } from "./config";
+import { resolveTypescript } from "./resolve/resolveTypescript";
+
+export function resolve(
+  filePath: string,
+  importPath: string,
+  config?: Partial<Config>
+): string {
+  if (!config) {
+    // perhaps fetch config from filePath
+    return importPath;
+  }
+  if (config.tsconfig) {
+    return resolveTypescript(filePath, importPath, config as any);
+  }
+  // rest of the configurations would go here
+  return importPath;
+}

--- a/src/index/resolve/resolveTypescript.test.ts
+++ b/src/index/resolve/resolveTypescript.test.ts
@@ -1,0 +1,20 @@
+import { resolveTypescript } from "./resolveTypescript";
+
+describe("tsconfig", () => {
+  const tsconfig = {
+    baseUrl: ".",
+    paths: { "@/*": ["./*"] },
+  };
+
+  it("should not resolve relative paths", () => {
+    expect(
+      resolveTypescript("./page/a.ts", "../b", { tsconfig, root: "." })
+    ).toBe("../b");
+  });
+
+  it("should resolve from root", () => {
+    expect(
+      resolveTypescript("./page/a.ts", "@/shared/b", { tsconfig, root: "." })
+    ).toBe("../shared/b");
+  });
+});

--- a/src/index/resolve/resolveTypescript.ts
+++ b/src/index/resolve/resolveTypescript.ts
@@ -1,0 +1,63 @@
+import { dirname, relative, resolve as resolvePath, extname } from "path";
+import { existsSync } from "fs";
+import { parse } from "url";
+import { Config } from "../config";
+
+function normalizePath(p: string) {
+  // Is extended length or has non-ascii chars (respectively)
+  if (/^\\\\\?\\/.test(p) || /[^\u0000-\u0080]+/.test(p)) {
+    return p;
+  }
+  // Normalize to forward slash and remove repeating slashes
+  return p.replace(/[\\\/]+/g, "/");
+}
+
+function isRelative(s: string) {
+  return s[0] === ".";
+}
+
+function isUrl(s: string) {
+  return parse(s).protocol !== null;
+}
+
+export function resolveTypescript(
+  filePath: string,
+  importPath: string,
+  config: Pick<Config, "tsconfig" | "root">
+) {
+  if (isRelative(importPath)) {
+    // if it's relative path do not transform
+    return importPath;
+  }
+
+  const { tsconfig, root } = config;
+  const { paths = {}, rootDir } = tsconfig;
+
+  const sourceDir = dirname(filePath);
+
+  const binds = Object.entries(paths)
+    .filter(([_, paths]) => (paths as any).length)
+    .map(([key, paths]) => ({
+      regexp: new RegExp("^" + key.replace("*", "(.*)") + "$"),
+      paths: paths as any,
+    }));
+
+  for (const { regexp, paths } of binds) {
+    const match = regexp.exec(importPath);
+    if (match) {
+      for (const p of paths) {
+        const out = p.replace(/\*/g, match[1]);
+
+        if (isUrl(out)) return out;
+
+        const filepath = resolvePath(root, out);
+
+        const resolved = normalizePath(relative(sourceDir, filepath));
+
+        return isRelative(resolved) ? resolved : `./${resolved}`;
+      }
+    }
+  }
+
+  return importPath;
+}

--- a/src/index/resolveConfig.test.ts
+++ b/src/index/resolveConfig.test.ts
@@ -1,0 +1,13 @@
+import { resolve } from "path";
+import { resolveConfig } from "./resolveConfig";
+
+it("should find tsconfig.json", () => {
+  expect(
+    resolveConfig(resolve(__dirname, "__fixtures/page/main.ts"))
+  ).toMatchObject({
+    tsconfig: {
+      baseUrl: ".",
+      paths: { "@/*": ["./*"] },
+    },
+  });
+});

--- a/src/index/resolveConfig.ts
+++ b/src/index/resolveConfig.ts
@@ -1,0 +1,20 @@
+import { dirname, resolve as resolvePath } from "path";
+import { readFileSync } from "fs";
+import findUp from "find-up";
+import { Config } from "./config";
+
+function resolveTsconfig(cwd: string): Config["tsconfig"] | undefined {
+  const tsconfigFile = findUp.sync(["tsconfig.json", "jsconfig.json"], { cwd });
+  if (!tsconfigFile) {
+    return undefined;
+  }
+  const tsconfig = JSON.parse(readFileSync(tsconfigFile).toString())
+    .compilerOptions as any;
+  const { rootDir = "." } = tsconfig;
+  const root = dirname(tsconfigFile);
+  return { tsconfig, root };
+}
+
+export function resolveConfig(cwd: string): Partial<Config> {
+  return resolveTsconfig(cwd) ?? { root: cwd };
+}


### PR DESCRIPTION
This is some basic layout of how the api can be. I plan to work mainly on tsconfig support.

Basic tsconfig path resolution should work, I borrowed the code resolution logic from https://github.com/LeDDGroup/typescript-transform-paths, which should be fine for now but we should later consider using the typescript api for this.

See #1 

### Usage Example:

```ts
import { generateResolver } from "deema";

const resolve = generateResolver("/my/root/path");

resolve("src/component/main.ts", "@/shared/sum"); // "../shared/sum"
```

### TODO 

- [x] resolve tsconfig
- [x] clean up